### PR TITLE
Update the CDN link for mysql

### DIFF
--- a/files/brews/mysql.rb
+++ b/files/brews/mysql.rb
@@ -1,7 +1,7 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/5.6/en/"
-  url "https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.31.tar.gz"
+  url "https://dev.mysql.com/Downloads/MySQL-5.6/mysql-5.6.31.tar.gz"
   sha256 "6df1389bbf899025aee6be0f4a12b8b0135e6de7db83e3ea20201ad3633ba424"
 
   option :universal


### PR DESCRIPTION
Should fix https://github.com/intercom/boxen/issues/559

```
==> Downloading https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.31.tar.gz
Error: Failed to download resource "mysql"
Download failed: https://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.31.tar.gz
```

cc @eugeneius 